### PR TITLE
use `pushed_at` date for repo activity

### DIFF
--- a/checker/src/main.rs
+++ b/checker/src/main.rs
@@ -15,7 +15,7 @@ enum CheckResult {
 
 #[derive(Deserialize)]
 struct Repo {
-    updated_at: DateTime<Utc>,
+    pushed_at: DateTime<Utc>,
 }
 
 fn is_ok(status: StatusCode, url: &str) -> bool {
@@ -56,7 +56,7 @@ async fn check_repo(u: &str, token: &str) -> Result<CheckResult, Error> {
     let status = response.status();
     if is_ok(status, u) {
         let repo: Repo = response.json().await?;
-        if is_active(repo.updated_at) {
+        if is_active(repo.pushed_at) {
             return Ok(CheckResult::Success());
         }
         return Ok(CheckResult::Error(String::from("inactive")));


### PR DESCRIPTION
This is a change to url checker utility, and it should resolve an issue where repos can get flagged as inactive over latest update date, even though there are recent pushes to a repo. There is [this discussion](https://github.com/orgs/community/discussions/24442) of the difference, and it seems that looking at push dates is more relevant in this case. After this change, the inactivity date will be determined by repository `pushed_at` property, not by `updated_at` property. 