### PR TITLE
Add Video Size Reducer to multi-platform tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,12 +144,13 @@ Apps that can be used across multiple social media apps.
 | 20. | 🟦 | | [Storybeat](https://www.storybeat.com/) | iOS, Android | Add music to your stories |
 | 21. | 🟧 | | [Storyheap](https://storyheap.com/) | Web | Analytics for Snapchat & Instagram Stories |
 | 22. | 🟧 | | [Supportivekoala](https://supportivekoala.com/) | Web | Helps you and your team automate social media visuals, marketing images more |
-| 23. | 🟥 | | [Wavve](https://wavve.co/) | Web | Turn audio into animated videos for sharing |
-| 24. | 🟥 | | [Zubtitle](https://zubtitle.com/) | Web | Automatically add captions to any video |
-| 25. | 🟥 | | [SoundMadeSeen](https://soundmadeseen.com/) | Web | Create animated videos for sharing, add captions and create text content |
-| 26. | 🟨 | | [Statuz](https://statuz.gg) | MacOS | Cross-post to X, BlueSky and Mastodon straight from your menu bar |
-| 27. | 🟩 | [❋](https://github.com/non-npc/No-WEBP) | [No-WEBP](https://github.com/non-npc/No-WEBP) | Javascript | Chrome plugin to force original image formats (GIF, PNG, JPG) instead of WebP/AVIF |
-| 28. | 🟦 | | [WAVconverter](https://www.wavconverter.com/) | Web | Fast, free, secure audio file conversion for musicians and creators. |
+| 23. | 🟥 | | [Video Size Reducer](https://videosizereducer.org/) | Web | Compress video to a target file size to fit platform upload limits |
+| 24. | 🟥 | | [Wavve](https://wavve.co/) | Web | Turn audio into animated videos for sharing |
+| 25. | 🟥 | | [Zubtitle](https://zubtitle.com/) | Web | Automatically add captions to any video |
+| 26. | 🟥 | | [SoundMadeSeen](https://soundmadeseen.com/) | Web | Create animated videos for sharing, add captions and create text content |
+| 27. | 🟨 | | [Statuz](https://statuz.gg) | MacOS | Cross-post to X, BlueSky and Mastodon straight from your menu bar |
+| 28. | 🟩 | [❋](https://github.com/non-npc/No-WEBP) | [No-WEBP](https://github.com/non-npc/No-WEBP) | Javascript | Chrome plugin to force original image formats (GIF, PNG, JPG) instead of WebP/AVIF |
+| 29. | 🟦 | | [WAVconverter](https://www.wavconverter.com/) | Web | Fast, free, secure audio file conversion for musicians and creators. |
 
 * * *
 


### PR DESCRIPTION
Adds **Video Size Reducer** to *Multi-platform*.

| Field | Value |
| --- | --- |
| Link | https://videosizereducer.org/ |
| Legend | 🟥 Video |
| Platform | Web |

**Why it belongs here:** every platform in this list caps upload size — Discord at 10/25 MB depending on tier, and most others somewhere similar — and the usual fix is to run the footage through an online converter. This does the same job in the browser: you set a target size (10/25/50 MB or a custom limit) and it re-encodes to fit, using WebCodecs, so the file is never uploaded anywhere. Free, no signup, no watermark.

Sits next to the existing 🟥 entries (Recast Studio, Wavve, Zubtitle, SoundMadeSeen) and WAVconverter, which covers the same ground for audio.

Inserted alphabetically between Supportivekoala and Wavve, with the following rows renumbered — same shape as #138.
